### PR TITLE
Backport linux fix from upstream

### DIFF
--- a/crates/cli/src/binaries/platform.rs
+++ b/crates/cli/src/binaries/platform.rs
@@ -127,7 +127,7 @@ fn parse_openssl_version(v: &str) -> String {
     let matches = r.unwrap().captures(v).unwrap();
     if matches.len() > 0 {
         match matches.get(1).unwrap().as_str() {
-            "3.1" => "3.0.x".to_string(),
+            version if version.starts_with("3.") => "3.0.x".to_string(),
             version => format!("{version}.x"),
         }
     } else {


### PR DESCRIPTION
- always use 3.0.x for openssl 3